### PR TITLE
Fix bug where diff returned error on the same vectors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ScottKnottESD
 Type: Package
 Title: The Scott-Knott Effect Size Difference (ESD) Test
-Version: 2.0.3
-Date: 2018-05-08
+Version: 2.0.4
+Date: 2019-10-11
 Author: Chakkrit Tantithamthavorn
 Maintainer: Chakkrit Tantithamthavorn <kla@chakkrit.com>
 Description: The Scott-Knott Effect Size Difference (ESD) test is a mean comparison approach that leverages a hierarchical clustering to partition the set of treatment means (e.g., means of variable importance scores, means of model performance) into statistically distinct groups with non-negligible difference [Tantithamthavorn et al., (2018) <doi:10.1109/TSE.2018.2794977>].

--- a/R/partition.R
+++ b/R/partition.R
@@ -43,6 +43,10 @@ Partition <- function(g,
         
         a <- av$model[av$model[,2] == names(means[k]),1]
         b <- av$model[av$model[,2] == names(means[g]),1]  
+
+        if (all(a==b)) {
+            return(TRUE)
+        }
         
         magnitude <- as.character(cohen.d(a,b)$magnitude)
         return(magnitude == "negligible")


### PR DESCRIPTION
Hi,

this PR closes the issue #17 where sk_esd of same vectors threw an error.
To reproduce:
```R
sk_esd(data.frame(c(1,1,1,1,1), c(1,1,1,1,1)))
```

Cheers
Christoph
