### PR TITLE
Fix python ranking example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,15 @@ pandas2ri.activate()
 import pandas as pd
 
 sk = importr('ScottKnottESD')
-data = pd.read_csv("data.csv")
+data = pd.DataFrame(
+    {
+        "TechniqueA": [5, 1, 4],
+        "TechniqueB": [6, 8, 3],
+        "TechniqueC": [7, 10, 15],
+        "TechniqueD": [7, 10.1, 15],
+    }
+)
+display(data)
 r_sk = sk.sk_esd(data)
 ranking = pd.DataFrame({'columns':r_sk[2], 'rank':list(r_sk[1])}) # long format
 ranking = pd.DataFrame([list(r_sk[1])], columns=r_sk[2]) # wide format

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ data = pd.DataFrame(
 )
 display(data)
 r_sk = sk.sk_esd(data)
-column_order = [i - 1 for i in list(r_sk[3])]
+column_order = list(r_sk[3] - 1)
 ranking = pd.DataFrame(
     {
         "technique": [data.columns[i] for i in column_order],

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install rpy2
 env ARCHFLAGS="-arch i386 -arch x86_64" pip install rpy2
 ```
 
-```
+```python
 from rpy2.robjects.packages import importr
 from rpy2.robjects import r, pandas2ri
 pandas2ri.activate()

--- a/README.md
+++ b/README.md
@@ -109,8 +109,16 @@ data = pd.DataFrame(
 )
 display(data)
 r_sk = sk.sk_esd(data)
-ranking = pd.DataFrame({'columns':r_sk[2], 'rank':list(r_sk[1])}) # long format
-ranking = pd.DataFrame([list(r_sk[1])], columns=r_sk[2]) # wide format
+column_order = [i - 1 for i in list(r_sk[3])]
+ranking = pd.DataFrame(
+    {
+        "technique": [data.columns[i] for i in column_order],
+        "rank": r_sk[1].astype("int"),
+    }
+) # long format
+ranking = pd.DataFrame(
+    [r_sk[1].astype("int")], columns=[data.columns[i] for i in column_order]
+) # wide format
 ```
 ### Referencing ScottKnottESD
 ScottKnottESD can be referenced as:


### PR DESCRIPTION
In this PR, I'm adding a solution for the issue https://github.com/klainfo/ScottKnottESD/issues/24. Changes include:

* Fixed ranking by creating the right `column_order`.
* Improved code visualization for the Python example.
* `data` variable was previously read from the unavailable file`data.csv`, now it is changed to a hard-coded DataFrame for a better testing experience.
* Ranks are represented as integers instead of floats.

## DataFrames created by this solution

Long format
|technique|rank|
|---|---|
|TechniqueD|1|
|TechniqueC|1|
|TechniqueB|2|
|TechniqueA|3|

Wide format
|TechniqueD|TechniqueC|TechniqueB|TechniqueA|
|---|---|---|---|
|1|1|2|3|